### PR TITLE
Release v0.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,38 +6,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
+## [0.0.5] - 2019-03-08
+
+### Added
+* Two new demos: `usage-grid-social-network.py` and `usage-concentric-social-network.py`
+* Add Issue and PR templates for Github (located in `.github`)
 * `tests.test_usage`: Tests for rendering usage files.
 * `tests.test_callbacks`: Tests for updating `Cytoscape` with callbacks.
 * `tests.test_interactions`: Tests for interacting with `Cytoscape`, and evaluating its event callbacks.
 * `tests.test_percy_snapshot`: Creates a Percy build using screenshots from other tests.
 
-## Changed
-* `config.yml`: Added steps to run the new tests. Added coverage for Python 3.7. Included `demos` and all usage examples in `pylint` and `flake8`. Increased line limit to 100.
+### Changed
+* `usage-*.py`: Modified all the import statements from `import dash_cytoscape` to `import dash_cytoscape as cyto`. Optimized imports. They are now linted with pylint/flake8.
 * `demos/usage-*`: Formatted all demo apps in order to respect pylint and flake8.
-* `usage-*`: Formatted all demo apps in order to respect pylint and flake8.
+* `usage-phylogeny.py`: Clear callback conditional statement
+* `CONTRIBUTING.md`: changed `dash-cytoscape-0.0.1` to `dash-cytoscape-x.x.x`. Added a **Code quality & design** section. Changed the **Making a contribution** section and updated title to **Publishing**. Updated **Pre-Release checklist**. Added the **Development** section from `README.md` (renamed **Setting up the environment**). Added a **Tests** section.
+* `npmignore`: Added `venv` to avoid venvs to be included in the npm distribution package, which makes us a large amount of space and many unnecessary files being distributed.
+* `config.yml`: Added steps to run the new tests. Added coverage for Python 3.7. Included `demos` and all usage examples in `pylint` and `flake8`. Increased line limit to 100.
+* `README.md`: Moved the **Development** section to `CONTRIBUTING.md`. Modified the dash version in **Prerequisites**.
+* `requirements.txt`: Updated the dash version to latest.
+* `tests/requiremens.txt`: Updated the dash version to latest.
 * `package.json`: Removed `"prepublish": "npm run validate-init"` due to conflict with CircleCI build. This script will be deprecated in favor of the upcoming Dash Component CLI.
 * `tests/IntegrationTests.py`: Moved the `percy_snapshot` method to `test_percy_snapshot` in order to avoid duplicate (failing) builds on Percy. Decrease the number of processes to 1.
+* `setup.py`: Added classifiers and download_url.
 
-## Removed
-* `tests.test_render`: Removed unused test
-
-## Added
-* Two new demos: `usage-grid-social-network.py` and `usage-concentric-social-network.py`
-* Add Issue and PR templates for Github (located in `.github`)
-
-## Changed
-* `usage-*.py` - Modified all the import statements from `import dash_cytoscape` to `import dash_cytoscape as cyto`. Also optimized imports.
-* `usage-phylogeny.py` - Clear callback conditional statement
-* `CONTRIBUTING.md` - changed `dash-cytoscape-0.0.1` to `dash-cytoscape-x.x.x`. Added a **Code quality & design** section. Changed the **Making a contribution** section and updated title to **Publishing**. Updated **Pre-Release checklist**.
-* `npmignore` - Added `venv` to avoid venvs to be included in the npm distribution package, which makes us a large amount of space and many unnecessary files being distributed.
-
-## Removed
+### Removed
 * `extract-meta.js`, `extract-meta` - they were moved to the dash component CLI, thus are not needed anymore
 * `config.py`, `runtime.txt`, `Procfile`, `index.html` - only needed for hosting `usage-*.py` on DDS, they are now moved to `plotly/dash-cytoscape-demos`.
 * `review_checklist.md` -  redundant since all the information is already contained in CONTRIBUTING.md
+* `tests.test_render`: Removed unused test
 
-## [0.0.4] - 2018-01-19
+
+## [0.0.4] - 2019-01-19
 
 ### Added
 * Homepage URL for PyPi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,45 @@
 # Contributing to Dash Cytoscape
 
-## Getting Started
+Thank you for your interesting in contributing to this open-source project! Make sure that you have read and understood our [code of conduct](CODE_OF_CONDUCT.md).
 
-Refer to the [readme](README.md) for installation and development instructions.
+## Setting up the environment
+
+Please follow the following steps for local testing:
+
+1. Clone the repo
+```commandline
+git clone https://github.com/plotly/dash-cytoscape.git
+```
+2. In order to run the Python builds (`npm run build:py`) you need to create a 
+venv for this project. Make sure you have `virtualenv` correctly installed and run this:
+```commandline
+mkdir dash_cytoscape_dev
+cd dash_cytoscape_dev
+virtualenv venv  # Create a virtual env
+source venv/bin/activate  # Activate the venv
+pip install -r requirements.txt  # Install the requirements
+```
+
+To activate in windows, replace the 4th line with this:
+```commandline
+venv\Scripts\activate 
+```
+
+3. Install the JavaScript dependencies and build the code:
+```commandline
+yarn
+yarn run build:all
+```
 
 ## Coding Style
 
-Please lint any additions to Python code with `pylint` and `flake8`.
+Please lint any additions to Python code with `pylint` and `flake8`:
+```commandline
+flake8 --max-line-length=100 usage.py usage-advanced.py usage-elements.py usage-events.py usage-stylesheet.py
+flake8 --max-line-length=100 demos tests
+pylint usage.py usage-advanced.py usage-elements.py usage-events.py usage-stylesheet.py
+pylint demos tests
+```
 
 ## Code quality & design
 
@@ -27,10 +60,51 @@ Please lint any additions to Python code with `pylint` and `flake8`.
 *   Can you think of cases where your current code will break? How are you handling errors? Should the user see them as notifications? Should your app try to auto-correct them for them?
 
 
-## Running the Tests
+## Tests
 
-_To be added_
+### Running the tests
 
+Activate your virtualenv:
+```commandline
+source venv/bin/activate
+```
+
+If needed, install the requirements:
+```commandline
+pip install -r tests/requirements.txt
+```
+
+Run the following tests:
+```commandline
+python -m unittest tests.test_callbacks
+python -m unittest tests.test_interactions
+python -m unittest tests.test_usage
+```
+
+Look inside the `tests/screenshots` directory to find the images created by the tests. If you have
+Percy configured, run the following test:
+```commandline
+python -m unittest tests.test_percy_snapshot
+``` 
+
+### Percy
+
+Make sure to configure your Percy environment variables correctly:
+```commandline
+PERCY_BRANCH=local
+PERCY_ENABLED=1
+PERCY_TOKEN=***************
+```
+
+You can find the token in the [project settings of the Percy project](https://percy.io/plotly/dash-cytoscape/settings). Only members of the Plotly organizations have access to this token.
+
+### About the tests
+The tests are broken down in 3 categories:
+* Callbacks: Tests if the `elements`, `stylesheet` and `layout` properties can be updated correctly by other Dash components using callbacks.
+* Interactions: Tests user interactions such as dragging, clicking, and hovering over nodes, as well as the associated event callbacks.
+* Usage: Tests if all of the usage apps render correctly on start. This does not test callbacks.
+
+Those tests are rendered into images located inside `tests/screenshots`, which are then sent to a Percy build using `tests.test_percy_snapshot`, which creates a Dash app that only serves the content of `tests/screenshots` at different routes, which are then captured by the Percy runner.
 
 ## Publishing
 
@@ -41,7 +115,7 @@ After a review has been done and your changes have been approved, create a prere
 To publish or create a prerelease:
 
 1. Check `MANIFEST.in` has all of the extra files (like CSS)
-2. Bump version numbers in `package.json`, update the `CHANGELOG.md`, and make a pull request
+2. Bump version numbers in `package.json`, update the [CHANGELOG](CHANGELOG.md), and make a pull request
 3. Once the pull request is merged into master:
 4. Build
 ```
@@ -117,6 +191,12 @@ Complete the "Publishing" section.
 - [ ] You have closed all issues that this pull request solves, and commented the new version number users should install.
 - [ ] If significant enough, you have created an issue about documenting the new feature or change and you have added it to the [Documentation] project.
 - [ ] You have created a pull request in [Dash Docs] with the new release of your feature by editing that project's [`requirements.txt` file](https://github.com/plotly/dash-docs/blob/master/requirements.txt) and you have assigned `@chriddyp` to review.
+
+## Notes
+
+#### Package manager
+Our preferred package manager for this project is Yarn. Therefore we use `yarn.lock` rather than `package-lock.json`. If you decide to start using npm for package management (which will create package-lock.json) and you commit this project to Dokku, make sure to delete `yarn.lock`.
+
 
 ## Financial Contributions
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,13 @@ Interacting with the elements:
 
 ### Prerequisites
 
-Make sure that the following python packages are installed:
-
-```
-dash==0.35.1
-dash-renderer==0.14.3
-dash-html-components==0.13.4
-dash-core-components==0.42.1
+Make sure that dash and its dependent libraries are correctly installed:
+```commandline
+pip install dash dash-html-components
 ```
 
-Older versions are not necessarily incompatible, but have not been extensively tested.
+If you want to install the latest versions, check out the [Dash docs on installation](https://dash.plot.ly/installation).
+
 
 ### Usage
 

--- a/README.md
+++ b/README.md
@@ -64,47 +64,9 @@ To learn more about the core Dash components and how to use callbacks, view the 
 
 For supplementary information about the underlying Javascript  API, view the [Cytoscape.js documentation](http://js.cytoscape.org/).
 
-## Development
+### Development and Contributions
 
-Please follow the following steps for local testing:
-
-1. Clone the repo
-```commandline
-$ git clone https://github.com/plotly/dash-cytoscape.git
-```
-2. In order to run the Python builds (`npm run build:py`) you need to create a 
-venv for this project. Make sure you have `virtualenv` correctly installed and run this:
-```commandline
-$ mkdir dash_cytoscape_dev
-$ cd dash_cytoscape_dev
-$ virtualenv venv  # Create a virtual env
-$ source venv/bin/activate  # Activate the venv
-```
-
-To activate in windows:
-```commandline
-> venv\Scripts\activate
-```
-(and then repeat step 3).
-
-3. Install the JavaScript dependencies and build the code:
-```commandline
-$ yarn
-$ yarn run build:all
-```
-
-4. Install the library
-```commandline
-$ python setup.py install
-```
-
-
-
-## Notes
-
-#### Package manager
-Our preferred package manager for this project is Yarn. Therefore we use `yarn.lock` rather than `package-lock.json`. If you decide to start using npm for package management (which will create package-lock.json) and you commit this project to Dokku, make sure to delete `yarn.lock`.
-
+Make sure that you have read and understood our [code of conduct](CODE_OF_CONDUCT.md), then head over to [CONTRIBUTING](CONTRIBUTING.md) to get started. 
 
 ## License
 

--- a/dash_cytoscape/package.json
+++ b/dash_cytoscape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-cytoscape",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-cytoscape",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js",
   "main": "build/index.js",
   "scripts": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,6 @@
-# Core
-gunicorn>=19.8.1
-plotly==3.3.0
-dash==0.35.1
-dash-renderer==0.14.3
-dash-html-components==0.13.4
-dash-core-components==0.42.1
+biopython
+gunicorn
+plotly
+dash>=0.38.0
 
 colour==0.1.5

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,30 @@ setup(
     description=package['description'] if 'description' in package else package_name,
     long_description=io.open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
+    url='https://dash.plot.ly/cytoscape',
+    download_url='https://github.com/plotly/dash-cytoscape/releases',
     install_requires=[
         'dash',
         'dash-html-components',
         'dash_renderer',
     ],
-    url='https://dash.plot.ly/cytoscape'
+    classifiers=[
+        'Environment :: Web Environment',
+        'Framework :: Flask',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Education',
+        'Intended Audience :: Financial and Insurance Industry',
+        'Intended Audience :: Healthcare Industry',
+        'Intended Audience :: Manufacturing',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'Topic :: Database :: Front-Ends',
+        'Topic :: Scientific/Engineering :: Visualization',
+        'Topic :: Software Development :: Libraries :: Application Frameworks',
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(
     long_description=io.open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown',
     url='https://dash.plot.ly/cytoscape',
-    download_url='https://github.com/plotly/dash-cytoscape/releases',
     install_requires=[
         'dash',
         'dash-html-components',


### PR DESCRIPTION
# [0.0.5] - 2019-03-08

### Added
* Two new demos: `usage-grid-social-network.py` and `usage-concentric-social-network.py`
* Add Issue and PR templates for Github (located in `.github`)
* `tests.test_usage`: Tests for rendering usage files.
* `tests.test_callbacks`: Tests for updating `Cytoscape` with callbacks.
* `tests.test_interactions`: Tests for interacting with `Cytoscape`, and evaluating its event callbacks.
* `tests.test_percy_snapshot`: Creates a Percy build using screenshots from other tests.

### Changed
* `usage-*.py`: Modified all the import statements from `import dash_cytoscape` to `import dash_cytoscape as cyto`. Optimized imports. They are now linted with pylint/flake8.
* `demos/usage-*`: Formatted all demo apps in order to respect pylint and flake8.
* `usage-phylogeny.py`: Clear callback conditional statement
* `CONTRIBUTING.md`: changed `dash-cytoscape-0.0.1` to `dash-cytoscape-x.x.x`. Added a **Code quality & design** section. Changed the **Making a contribution** section and updated title to **Publishing**. Updated **Pre-Release checklist**. Added the **Development** section from `README.md` (renamed **Setting up the environment**). Added a **Tests** section.
* `npmignore`: Added `venv` to avoid venvs to be included in the npm distribution package, which makes us a large amount of space and many unnecessary files being distributed.
* `config.yml`: Added steps to run the new tests. Added coverage for Python 3.7. Included `demos` and all usage examples in `pylint` and `flake8`. Increased line limit to 100.
* `README.md`: Moved the **Development** section to `CONTRIBUTING.md`. Modified the dash version in **Prerequisites**.
* `requirements.txt`: Updated the dash version to latest.
* `tests/requiremens.txt`: Updated the dash version to latest.
* `package.json`: Removed `"prepublish": "npm run validate-init"` due to conflict with CircleCI build. This script will be deprecated in favor of the upcoming Dash Component CLI.
* `tests/IntegrationTests.py`: Moved the `percy_snapshot` method to `test_percy_snapshot` in order to avoid duplicate (failing) builds on Percy. Decrease the number of processes to 1.
* `setup.py`: Added classifiers and download_url.

### Removed
* `extract-meta.js`, `extract-meta` - they were moved to the dash component CLI, thus are not needed anymore
* `config.py`, `runtime.txt`, `Procfile`, `index.html` - only needed for hosting `usage-*.py` on DDS, they are now moved to `plotly/dash-cytoscape-demos`.
* `review_checklist.md` -  redundant since all the information is already contained in CONTRIBUTING.md
* `tests.test_render`: Removed unused test