### PR TITLE
Patch v0.1.1 - Fix error where dash_cytoscape.utils cannot be imported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2019-04-05
+
+### Fixed
+* Error where `dash_cytoscape.utils` cannot be imported.
+
 ## [0.1.0] - 2019-04-05
 
 ### Added

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,6 @@ include dash_cytoscape/dash_cytoscape_extra.min.js
 include dash_cytoscape/dash_cytoscape_extra.dev.js
 include dash_cytoscape/metadata.json
 include dash_cytoscape/package.json
+include dash_cytoscape/utils
 include README.md
 include LICENSE

--- a/dash_cytoscape/package.json
+++ b/dash_cytoscape/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-cytoscape",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js",
   "main": "build/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dash-cytoscape",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js",
   "main": "build/index.js",
   "scripts": {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: 
https://github.com/plotly/dash-cytoscape/blob/master/CONTRIBUTING.md
-->


## About
<!--
What is your PR about? It could be that:
- This is a new component
- I am adding a feature to an existing component, or improving an existing feature
- I am closing an issue
--> 

Importing utils will cause an error in v0.1.0. This problem is fixed in v0.1.1


## Description of changes 
<!--
What does this implement/fix? Explain your changes.
-->

## Pre-Merge checklist
- [x] The project was correctly built with `npm run build:all`.
- [x] If there was any conflict, it was solved correctly
- [x] All changes were documented in CHANGELOG.md.
- [x] All tests on CircleCI have passed.
- [x] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash Cytoscape core contributor.


## Reference Issues
<!--
Example: Closes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests

If you are adding a new feature, consider discussing it by opening up an issue.
Otherwise, delete the following line:
-->

Closes #[issue number]


## Other comments