### PR TITLE
Updated dashCytoscape for Dash for R 0.1.0

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,6 +7,11 @@ lib/
 .builderrc
 .eslintrc
 .npmignore
+.editorconfig
+.eslintignore
+.prettierrc
+.circleci
+.github
 
 # demo folder has special meaning in R
 # this should hopefully make it still

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 * Contributed initial build of R package.
+* Updated R package build for compatibility with versions of Dash for R ≥ 0.1.0.
 
 ### Changed
 * `utils.Tree`: v0.1.1 broke compatibility with Python 2. Therefore, modified code to be compatible

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: dashCytoscape
-Title: A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js
+Title: Interactive Network Visualization Component for Dash 
 Version: 0.1.1
 Authors @R: as.person(c(The Plotly Team <cytoscape@plot.ly>))
-Description: A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js
+Description: A Component Library for Dash aimed at facilitating network visualization in R, wrapped around Cytoscape.js
 Depends: R (>= 3.0.2)
 Imports: dash
 Suggests: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,11 +5,11 @@ Authors @R: as.person(c(The Plotly Team <cytoscape@plot.ly>))
 Description: A Component Library for Dash aimed at facilitating network visualization in Python, wrapped around Cytoscape.js
 Depends: R (>= 3.0.2)
 Imports: dash
-Suggests: testthat, roxygen2
+Suggests: 
 License: MIT + file LICENSE
 URL: https://github.com/plotly/dash-cytoscape
 BugReports: https://github.com/plotly/dash-cytoscape/issues
 Encoding: UTF-8
 LazyData: true
 Author: The Plotly Team [aut]
-Maintainer: The Plotly Team <cytoscape@plot.ly>
+Maintainer: Ryan Patrick Kyle <ryan@plot.ly>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,5 @@
 # AUTO GENERATED FILE - DO NOT EDIT
 
 export(cytoCytoscape)
+
+import(dash)

--- a/R/cytoCytoscape.R
+++ b/R/cytoCytoscape.R
@@ -2,16 +2,17 @@
 
 cytoCytoscape <- function(id=NULL, className=NULL, style=NULL, elements=NULL, stylesheet=NULL, layout=NULL, pan=NULL, zoom=NULL, panningEnabled=NULL, userPanningEnabled=NULL, minZoom=NULL, maxZoom=NULL, zoomingEnabled=NULL, userZoomingEnabled=NULL, boxSelectionEnabled=NULL, autoungrabify=NULL, autolock=NULL, autounselectify=NULL, autoRefreshLayout=NULL, tapNode=NULL, tapNodeData=NULL, tapEdge=NULL, tapEdgeData=NULL, mouseoverNodeData=NULL, mouseoverEdgeData=NULL, selectedNodeData=NULL, selectedEdgeData=NULL) {
     
+    props <- list(id=id, className=className, style=style, elements=elements, stylesheet=stylesheet, layout=layout, pan=pan, zoom=zoom, panningEnabled=panningEnabled, userPanningEnabled=userPanningEnabled, minZoom=minZoom, maxZoom=maxZoom, zoomingEnabled=zoomingEnabled, userZoomingEnabled=userZoomingEnabled, boxSelectionEnabled=boxSelectionEnabled, autoungrabify=autoungrabify, autolock=autolock, autounselectify=autounselectify, autoRefreshLayout=autoRefreshLayout, tapNode=tapNode, tapNodeData=tapNodeData, tapEdge=tapEdge, tapEdgeData=tapEdgeData, mouseoverNodeData=mouseoverNodeData, mouseoverEdgeData=mouseoverEdgeData, selectedNodeData=selectedNodeData, selectedEdgeData=selectedEdgeData)
+    if (length(props) > 0) {
+        props <- props[!vapply(props, is.null, logical(1))]
+    }
     component <- list(
-        props = list(id=id, className=className, style=style, elements=elements, stylesheet=stylesheet, layout=layout, pan=pan, zoom=zoom, panningEnabled=panningEnabled, userPanningEnabled=userPanningEnabled, minZoom=minZoom, maxZoom=maxZoom, zoomingEnabled=zoomingEnabled, userZoomingEnabled=userZoomingEnabled, boxSelectionEnabled=boxSelectionEnabled, autoungrabify=autoungrabify, autolock=autolock, autounselectify=autounselectify, autoRefreshLayout=autoRefreshLayout, tapNode=tapNode, tapNodeData=tapNodeData, tapEdge=tapEdge, tapEdgeData=tapEdgeData, mouseoverNodeData=mouseoverNodeData, mouseoverEdgeData=mouseoverEdgeData, selectedNodeData=selectedNodeData, selectedEdgeData=selectedEdgeData),
+        props = props,
         type = 'Cytoscape',
         namespace = 'dash_cytoscape',
         propNames = c('id', 'className', 'style', 'elements', 'stylesheet', 'layout', 'pan', 'zoom', 'panningEnabled', 'userPanningEnabled', 'minZoom', 'maxZoom', 'zoomingEnabled', 'userZoomingEnabled', 'boxSelectionEnabled', 'autoungrabify', 'autolock', 'autounselectify', 'autoRefreshLayout', 'tapNode', 'tapNodeData', 'tapEdge', 'tapEdgeData', 'mouseoverNodeData', 'mouseoverEdgeData', 'selectedNodeData', 'selectedEdgeData'),
         package = 'dashCytoscape'
         )
 
-    component$props <- filter_null(component$props)
-
     structure(component, class = c('dash_component', 'list'))
 }
-

--- a/R/internal.R
+++ b/R/internal.R
@@ -2,14 +2,25 @@
 deps_metadata <- list(`dash_cytoscape` = structure(list(name = "dash_cytoscape",
 version = "0.1.1", src = list(href = NULL,
 file = "deps"), meta = NULL,
-script = "dash_cytoscape.min.js",
-stylesheet = NULL, head = NULL, attachment = NULL, package = "dashCytoscape",
-all_files = FALSE), class = "html_dependency"),
-`dash_cytoscape_dev` = structure(list(name = "dash_cytoscape",
-version = "0.1.1", src = list(href = NULL,
-file = "deps"), meta = NULL,
-script = "dash_cytoscape.dev.js",
+script = 'dash_cytoscape.min.js',
 stylesheet = NULL, head = NULL, attachment = NULL, package = "dashCytoscape",
 all_files = FALSE), class = "html_dependency"))
 return(deps_metadata)
+}
+
+dash_assert_valid_wildcards <- function (attrib = list("data", "aria"), ...)
+{
+    args <- list(...)
+    validation_results <- lapply(names(args), function(x) {
+        grepl(paste0("^", attrib, "-[a-zA-Z0-9]{1,}$", collapse = "|"),
+            x)
+    })
+    if (FALSE %in% validation_results) {
+        stop(sprintf("The following wildcards are not currently valid in Dash: '%s'",
+            paste(names(args)[grepl(FALSE, unlist(validation_results))],
+                collapse = ", ")), call. = FALSE)
+    }
+    else {
+        return(args)
+    }
 }

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -1,0 +1,4 @@
+pkg_help_description: >
+    A Component Library for Dash aimed at facilitating network visualizat    ion in R, wrapped around Cytoscape.js.
+pkg_help_title: >
+    Interactive Network Visualization Component for Dash

--- a/dash-info.yaml
+++ b/dash-info.yaml
@@ -1,4 +1,4 @@
 pkg_help_description: >
-    A Component Library for Dash aimed at facilitating network visualizat    ion in R, wrapped around Cytoscape.js.
+    A Component Library for Dash aimed at facilitating network visualization in R, wrapped around Cytoscape.js.
 pkg_help_title: >
     Interactive Network Visualization Component for Dash

--- a/man/cytoCytoscape.Rd
+++ b/man/cytoCytoscape.Rd
@@ -10,13 +10,13 @@ A Component Library for Dash aimed at facilitating network visualization in Pyth
 }
 
 \usage{
-cytoCytoscape(id=NULL, className=NULL, style=NULL, elements=NULL,
-stylesheet=NULL, layout=NULL, pan=NULL, zoom=NULL, panningEnabled=NULL,
-userPanningEnabled=NULL, minZoom=NULL, maxZoom=NULL, zoomingEnabled=NULL,
-userZoomingEnabled=NULL, boxSelectionEnabled=NULL, autoungrabify=NULL,
-autolock=NULL, autounselectify=NULL, autoRefreshLayout=NULL, tapNode=NULL,
-tapNodeData=NULL, tapEdge=NULL, tapEdgeData=NULL, mouseoverNodeData=NULL,
-mouseoverEdgeData=NULL, selectedNodeData=NULL, selectedEdgeData=NULL)
+cytoCytoscape(id=NULL, className=NULL, style=NULL, elements=NULL, stylesheet=NULL,
+layout=NULL, pan=NULL, zoom=NULL, panningEnabled=NULL, userPanningEnabled=NULL,
+minZoom=NULL, maxZoom=NULL, zoomingEnabled=NULL, userZoomingEnabled=NULL,
+boxSelectionEnabled=NULL, autoungrabify=NULL, autolock=NULL,
+autounselectify=NULL, autoRefreshLayout=NULL, tapNode=NULL, tapNodeData=NULL,
+tapEdge=NULL, tapEdgeData=NULL, mouseoverNodeData=NULL, mouseoverEdgeData=NULL,
+selectedNodeData=NULL, selectedEdgeData=NULL)
 }
 
 \arguments{
@@ -27,7 +27,7 @@ class attribute).}
 
 \item{style}{Named list. Add inline styles to the root element.}
 
-\item{elements}{List. A list of dictionaries representing the elements of the networks.
+\item{elements}{List of named lists. A list of dictionaries representing the elements of the networks.
     1. Each dictionary describes an element, and specifies its purpose.
         - `group` (string): Either 'nodes' or 'edges'. If not given, it's automatically inferred.
         - `data` (dictionary): Element specific data.
@@ -47,7 +47,7 @@ class attribute).}
 
     2. The [official Cytoscape.js documentation](http://js.cytoscape.org/#notation/elements-json) offers an extensive overview and examples of element declaration.}
 
-\item{stylesheet}{List. A list of dictionaries representing the styles of the elements.
+\item{stylesheet}{List of named lists. A list of dictionaries representing the styles of the elements.
     1. Each dictionary requires the following keys:
         - `selector` (string): Which elements you are styling. Generally, you select a group of elements (node, edges, both), a class (that you declare in the element dictionary), or an element by ID.
         - `style` (dictionary): What aspects of the elements you want to modify. This could be the size or color of a node, the shape of an edge arrow, or many more.
@@ -203,4 +203,3 @@ Shift+Click to select multiple nodes, or Shift+Drag to use box selection). Read-
 \item{selectedEdgeData}{Unnamed list. The list of data dictionaries of all selected edges (e.g. using
 Shift+Click to select multiple nodes, or Shift+Drag to use box selection). Read-only.}
 }
-

--- a/man/dashCytoscape-package.Rd
+++ b/man/dashCytoscape-package.Rd
@@ -1,0 +1,13 @@
+% Auto-generated: do not edit by hand
+\docType{package}
+\name{dashCytoscape-package}
+\alias{dashCytoscape}
+\title{Interactive Network Visualization Component for Dash
+}
+\description{
+A Component Library for Dash aimed at facilitating network visualizat    ion in R, wrapped around Cytoscape.js.
+
+}
+\author{
+\strong{Maintainer}: Ryan Patrick Kyle <ryan@plot.ly>
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "author": "The Plotly Team <cytoscape@plot.ly>",
   "author-email": "cytoscape@plot.ly",
+  "maintainer": "Ryan Patrick Kyle <ryan@plot.ly>",
   "license": "MIT",
   "dependencies": {
     "cytoscape-cola": "^2.3.0",


### PR DESCRIPTION
This PR proposes to commit a rebuilt version of the `dashCytoscape` R package, which is compatible with version 0.1.0 of `dash` for R.

Notably, the `filter_null` function logic has been embedded into generated components, so references to it have been removed in this version.