### PR TITLE
latest biopython doesn't support py2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-biopython
+biopython>=1.77;python_version>="3.0"
+biopython==1.76;python_version=="2.7"
 gunicorn
 plotly
 dash==0.39.0

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -11,4 +11,5 @@ flake8
 pylint
 pytest-dash>=2.1.1
 colour==0.1.5
-biopython
+biopython>=1.77;python_version>="3.0"
+biopython==1.76;python_version=="2.7"


### PR DESCRIPTION
Seems a bit odd to drop a major Python version in a minor package version, but [so it goes](https://github.com/biopython/biopython/blob/master/NEWS.rst#25-may-2020-biopython-177)

> ## 25 May 2020: Biopython 1.77
>
> This release of Biopython supports Python 3.6, 3.7 and 3.8 It has also been tested on PyPy3.6.1 v7.1.1-beta0.
>
> We have dropped support for Python 2 now.

