### PR TITLE
Improve setup.py: Fix `utils` import issues, and remove unneeded `install_requires`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the node's and edge's dictionaries, respectively (e.g., 'classes', 'positions', etc.).
 * Removed `Tree`'s method `add_child`, because it is redundant with `add_children` called with an
   argument of length 1.
+* `setup.py`: Remove `dash-html-components` and `dash_renderer` from `install_requires`
+* `setup.py`: Use `packages=find_packages(include=[package_name, package_name + ".*"])` so that all 
+  subpackages like `utils` will be included when you `pip install dash-cytoscape`.
 
 ## [0.1.1] - 2019-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Removed `Tree`'s method `add_child`, because it is redundant with `add_children` called with an
   argument of length 1.
 * `setup.py`: Remove `dash-html-components` and `dash_renderer` from `install_requires`
+
+### Fixed
 * `setup.py`: Use `packages=find_packages(include=[package_name, package_name + ".*"])` so that all 
   subpackages like `utils` will be included when you `pip install dash-cytoscape`.
 

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,6 @@ setup(
     url='https://dash.plotly.com/cytoscape',
     install_requires=[
         'dash',
-        'dash-html-components',
-        'dash_renderer',
     ],
     classifiers=[
         'Environment :: Web Environment',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import io
 import json
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
 
 
 with open(os.path.join('dash_cytoscape', 'package.json')) as f:
@@ -14,7 +14,7 @@ setup(
     version=package["version"],
     author=package['author'],
     author_email=package['author-email'],
-    packages=[package_name],
+    packages=find_packages(include=[package_name, package_name + ".*"]),
     include_package_data=True,
     license=package['license'],
     description=package['description'] if 'description' in package else package_name,


### PR DESCRIPTION
Closes https://github.com/plotly/dash-cytoscape/issues/89

Two changes to `setup.py`:
* Remove `dash-html-components` and `dash_renderer` from `install_requires`
* Use `packages=find_packages(include=[package_name, package_name + ".*"])` so that all subpackages like `utils` will be included when you `pip install dash-cytoscape`.