### PR TITLE
Add polyfill to fix context-menu extension in Safari

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
+        "@ungap/custom-elements": "^1.3.0",
         "cytoscape-cola": "^2.5.1",
         "cytoscape-context-menus": "^4.1.0",
         "cytoscape-cose-bilkent": "^4.1.0",
@@ -3098,6 +3099,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.7.0.tgz",
       "integrity": "sha512-zI22/pJW2wUZOVyguFaUL1HABdmSVxpXrzIqkjsHmyUjNhPoWM1CKfvVuXfetHhIok4RY573cqS0mZ1SJEnoTg==",
       "dev": true
+    },
+    "node_modules/@ungap/custom-elements": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/custom-elements/-/custom-elements-1.3.0.tgz",
+      "integrity": "sha512-f4q/s76+8nOy+fhrNHyetuoPDR01lmlZB5czfCG+OOnBw/Wf+x48DcCDPmMQY7oL8xYFL8qfenMoiS8DUkKBUw=="
     },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "author-email": "cytoscape@plotly.com",
   "license": "MIT",
   "dependencies": {
+    "@ungap/custom-elements": "^1.3.0",
     "cytoscape-cola": "^2.5.1",
     "cytoscape-context-menus": "^4.1.0",
     "cytoscape-cose-bilkent": "^4.1.0",
@@ -56,9 +57,9 @@
   "devDependencies": {
     "@babel/core": "^7.23.0",
     "@babel/eslint-parser": "^7.22.15",
-    "babel-loader": "^9.1.3",
     "@babel/preset-env": "^7.22.20",
     "@babel/preset-react": "^7.22.15",
+    "babel-loader": "^9.1.3",
     "copyfiles": "^2.4.1",
     "css-loader": "^6.8.1",
     "eslint": "^8.50.0",

--- a/src/lib/components/Cytoscape.react.js
+++ b/src/lib/components/Cytoscape.react.js
@@ -9,6 +9,10 @@ import CytoscapeComponent from 'react-cytoscapejs';
 import _ from 'lodash';
 import {v4 as uuidv4} from 'uuid';
 import CyResponsive from '../cyResponsive.js';
+
+// Polyfill so that context menu extension works in Safari
+import '@ungap/custom-elements';
+
 const cytoscape = require('cytoscape');
 const contextMenus = require('cytoscape-context-menus');
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: 
https://github.com/plotly/dash-cytoscape/blob/master/CONTRIBUTING.md
-->


## About

The `cytoscape-context-menu` extension causes a breaking "Illegal Constructor" error in Safari ([see issue here](https://github.com/iVis-at-Bilkent/cytoscape.js-context-menus/issues/55)).

![Screen Shot 2023-11-30 at 10 18 17 AM](https://github.com/plotly/dash-cytoscape/assets/4672118/815e307e-09eb-4b51-a3cb-d3d9adf0b550)
This can be fixed by adding an existing [polyfill](https://github.com/danieldietrich/candid/issues/17#issuecomment-1028455087) to the project. 

## Description of changes 
This PR adds the necessary polyfill to fix the "Illegal Constructor" error in Safari.


## Pre-Merge checklist
- [x] The project was correctly built with `npm run build:all`.
- [x] If there was any conflict, it was solved correctly.
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] Two people have :dancer:'d the pull request. You can be one of these people if you are a Dash Cytoscape core contributor.


## Steps to test

1. Check out branch
2. Run `npm install && npm run build:all`
3. Run the context menu demo Dash app: `python demos/usage-context-menu.py` and navigate to `http://127.0.0.1:8050` in **Safari**
4. If the app loads properly without an "Illegal Constructor" Javascript error, all is good.