### PR TITLE
Update optional leaflet dependency to (latest) stable version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "dash",
     ],
     extras_require={
-        "leaflet": ["dash-leaflet>=1.0.16rc3"],
+        "leaflet": ["dash-leaflet>=1.1.1"],
     },
     python_requires=">=3.8",
     classifiers=[

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -14,4 +14,4 @@ biopython>=1.77
 pytest==7.0.1
 wrapt==1.14.0
 black==23.9.1
-dash-leaflet>=1.0.16rc3
+dash-leaflet>=1.1.1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: 
https://github.com/plotly/dash-cytoscape/blob/master/CONTRIBUTING.md
-->


## Description of changes 
The optional leaflet dependency currently points to a release candidate.
To me, it seems better to point to a stable release instead.
Coincidentally, dash-leaflet 1.1.* was released today.

Note: dash-leaflet 1.1.0 had an issue ([see here](https://github.com/emilhe/dash-leaflet/releases/tag/1.1.1)), so I set the minimal requirement to 1.1.1






## Pre-Merge checklist
- [ ] The project was correctly built with `npm run build:all`.
- [x] If there was any conflict, it was solved correctly.
- [ ] All changes were documented in CHANGELOG.md.
- [ ] All tests on CircleCI have passed.
- [ ] All Percy visual changes have been approved.
- [ ] At least one person has :dancer:'d the pull request.


Closes #220


## Other comments
#### Python version
The miminum python requirement for dash-leaflet is now `>3.12`, while for dash-cytoscape it is `python_requires=">=3.8"`
Might be a good idea to start updating the minimum python version of dash-cytoscape too. For example, python 3.8 has already reached end-of-life (https://devguide.python.org/versions/)

In my experience, supporting the latest 3 stable versions (3.12, 3.13, 3.14) is a good practice
